### PR TITLE
fix: change dirsearch option

### DIFF
--- a/modules/dirsearchscan.py
+++ b/modules/dirsearchscan.py
@@ -29,7 +29,7 @@ def dirsearch_scan():
     conf.create_dir(dir_output)
 
     conf.os.system(
-        f"python3 {conf.home}/.local/share/dirsearch/dirsearch.py -u {dir_host} --simple-report={dir_output}/dirsearch.txt"
+        f"python3 {conf.home}/.local/share/dirsearch/dirsearch.py -u {dir_host} --output={dir_output}/dirsearch.txt"
     )
 
     print(


### PR DESCRIPTION
Hello,

In the following PR, dirsearch option `--simple-report` was removed, which prevented Dirsearch Scan from working properly.
I fixed this by changing it to the newly added option `--output`.

https://github.com/maurosoria/dirsearch/pull/770